### PR TITLE
Add a red_rollback call to Reliance-Edge.

### DIFF
--- a/core/driver/core.c
+++ b/core/driver/core.c
@@ -483,17 +483,18 @@ REDSTATUS RedCoreVolTransact(void)
     return ret;
 }
 
+
 /** @brief Rollback to a previous transaction point.
 
     Reliance Edge is a transactional file system.  All modifications, of both
-    metadata and filedata, are initially working state.  This call allows to
-    discard the current working state and get back to the last commited state.
+    metadata and filedata, are initially working state.  This call discards the
+    current working state and reverts to the last committed state.
 
     @return A negated ::REDSTATUS code indicating the operation result.
 
     @retval 0           Operation was successful.
     @retval -RED_EINVAL The volume is not mounted.
-    @retval -RED_EBUSY  A discaded block is still referenced
+    @retval -RED_EIO    An I/O error occurred.
     @retval -RED_EROFS  The file system volume is read-only.
 */
 REDSTATUS RedCoreVolRollback(void)

--- a/core/driver/core.c
+++ b/core/driver/core.c
@@ -482,6 +482,39 @@ REDSTATUS RedCoreVolTransact(void)
 
     return ret;
 }
+
+/** @brief Rollback to a previous transaction point.
+
+    Reliance Edge is a transactional file system.  All modifications, of both
+    metadata and filedata, are initially working state.  This call allows to
+    discard the current working state and get back to the last commited state.
+
+    @return A negated ::REDSTATUS code indicating the operation result.
+
+    @retval 0           Operation was successful.
+    @retval -RED_EINVAL The volume is not mounted.
+    @retval -RED_EBUSY  A discaded block is still referenced
+    @retval -RED_EROFS  The file system volume is read-only.
+*/
+REDSTATUS RedCoreVolRollback(void)
+{
+    REDSTATUS ret;
+
+    if(!gpRedVolume->fMounted)
+    {
+        ret = -RED_EINVAL;
+    }
+    else if(gpRedVolume->fReadOnly)
+    {
+        ret = -RED_EROFS;
+    }
+    else
+    {
+        ret = RedVolRollback();
+    }
+
+    return ret;
+}
 #endif /* REDCONF_READ_ONLY == 0 */
 
 

--- a/core/driver/volume.c
+++ b/core/driver/volume.c
@@ -374,8 +374,6 @@ REDSTATUS RedVolTransact(void)
 {
     REDSTATUS ret = 0;
 
-    REDASSERT(gpRedVolume->fMounted); /* Should be checked by caller. */
-
     REDASSERT(!gpRedVolume->fReadOnly); /* Should be checked by caller. */
 
     if(gpRedCoreVol->fBranched)
@@ -469,26 +467,27 @@ REDSTATUS RedVolTransact(void)
     return ret;
 }
 
+
 /** @brief Rollback to the previous transaction point.
 
     @return A negated ::REDSTATUS code indicating the operation result.
 
     @retval 0           Operation was successful.
-    @retval -RED_EBUSY  A discarded block is still referenced.
+    @retval -RED_EIO    An I/O error occurred.
 */
 REDSTATUS RedVolRollback(void)
 {
     REDSTATUS ret = 0;
 
     REDASSERT(gpRedVolume->fMounted); /* Should be checked by caller. */
-
     REDASSERT(!gpRedVolume->fReadOnly); /* Should be checked by caller. */
 
     if(gpRedCoreVol->fBranched)
     {
         ret = RedBufferDiscardRange(0U, gpRedVolume->ulBlockCount);
 
-        if(ret == 0) {
+        if(ret == 0)
+        {
             ret = RedVolMountMaster();
         }
 
@@ -507,7 +506,7 @@ REDSTATUS RedVolRollback(void)
 
     return ret;
 }
-#endif
+#endif /* REDCONF_READ_ONLY == 0 */
 
 
 #ifdef REDCONF_ENDIAN_SWAP

--- a/core/include/redcore.h
+++ b/core/include/redcore.h
@@ -244,6 +244,7 @@ REDSTATUS RedVolMountMaster(void);
 REDSTATUS RedVolMountMetaroot(uint32_t ulFlags);
 #if REDCONF_READ_ONLY == 0
 REDSTATUS RedVolTransact(void);
+REDSTATUS RedVolRollback(void);
 #endif
 void RedVolCriticalError(const char *pszFileName, uint32_t ulLineNum);
 REDSTATUS RedVolSeqNumIncrement(uint8_t bVolNum);

--- a/fse/fse.c
+++ b/fse/fse.c
@@ -628,6 +628,44 @@ REDSTATUS RedFseTransact(
 
     return ret;
 }
+
+/** @brief Rollback to a previous transaction point.
+
+    Reliance Edge is a transactional file system.  All modifications, of both
+    metadata and filedata, are initially working state.  A transaction point
+    is a process whereby the working state atomically becomes the committed
+    state, replacing the previous committed state.  Whenever Reliance Edge is
+    mounted, including after power loss, the state of the file system after
+    mount is the most recent committed state.  Nothing from the committed
+    state is ever missing, and nothing from the working state is ever included.
+    This call cancels all modifications in the working state and reverts to
+    the last committed state.
+
+    @param bVolNum  The volume number of the volume to rollback.
+
+    @return A negated ::REDSTATUS code indicating the operation result.
+
+    @retval 0           Operation was successful.
+    @retval -RED_EINVAL @p bVolNum is an invalid volume number or not mounted.
+    @retval -RED_EIO    A disk I/O error occurred.
+    @retval -RED_EROFS  The file system volume is read-only.
+*/
+REDSTATUS RedFseRollback(
+    uint8_t     bVolNum)
+{
+    REDSTATUS   ret;
+
+    ret = FseEnter(bVolNum);
+
+    if(ret == 0)
+    {
+        ret = RedCoreVolRollback();
+
+        FseLeave();
+    }
+
+    return ret;
+}
 #endif
 
 /** @} */

--- a/include/redcoreapi.h
+++ b/include/redcoreapi.h
@@ -50,6 +50,7 @@ REDSTATUS RedCoreVolMount(uint32_t ulFlags);
 REDSTATUS RedCoreVolUnmount(void);
 #if REDCONF_READ_ONLY == 0
 REDSTATUS RedCoreVolTransact(void);
+REDSTATUS RedCoreVolRollback(void);
 #endif
 #if REDCONF_API_POSIX == 1
 REDSTATUS RedCoreVolStat(REDSTATFS *pStatFS);

--- a/include/redfse.h
+++ b/include/redfse.h
@@ -92,6 +92,7 @@ REDSTATUS RedFseTransMaskGet(uint8_t bVolNum, uint32_t *pulEventMask);
 #endif
 #if REDCONF_READ_ONLY == 0
 REDSTATUS RedFseTransact(uint8_t bVolNum);
+REDSTATUS RedFseRollback(uint8_t bVolNum);
 #endif
 
 #endif /* REDCONF_API_FSE == 1 */

--- a/include/redposix.h
+++ b/include/redposix.h
@@ -143,6 +143,7 @@ int32_t red_format(const char *pszVolume);
 #endif
 #if REDCONF_READ_ONLY == 0
 int32_t red_transact(const char *pszVolume);
+int32_t red_rollback(const char *pszVolume);
 #endif
 #if REDCONF_READ_ONLY == 0
 int32_t red_settransmask(const char *pszVolume, uint32_t ulEventMask);

--- a/posix/posix.c
+++ b/posix/posix.c
@@ -647,9 +647,10 @@ int32_t red_format(
 
     <b>Errno values</b>
     - #RED_EINVAL: Volume is not mounted; or @p pszVolume is `NULL`.
-    - #RED_EIO: I/O error during the transaction point.
+    - #RED_EIO:    I/O error during the transaction point.
     - #RED_ENOENT: @p pszVolume is not a valid volume path prefix.
     - #RED_EUSERS: Cannot become a file system user: too many users.
+    - #RED_EROFS:  The file system volume is read-only.
 */
 int32_t red_transact(
     const char *pszVolume)
@@ -664,6 +665,72 @@ int32_t red_transact(
         if(ret == 0)
         {
             ret = RedCoreVolTransact();
+        }
+
+        PosixLeave();
+    }
+
+    return PosixReturn(ret);
+}
+
+/** @brief Rollback to the previous committed state
+
+    Reliance Edge is a transactional file system.  All modifications, of both
+    metadata and filedata, are initially working state.  A transaction point
+    is a process whereby the working state atomically becomes the committed
+    state, replacing the previous committed state.  Whenever Reliance Edge is
+    mounted, including after power loss, the state of the file system after
+    mount is the most recent committed state.  Nothing from the committed
+    state is ever missing, and nothing from the working state is ever included.
+    This call cancel all modifications of the working state and get back to
+    the last commited state.
+
+    @param pszVolume    A path prefix identifying the volume to rollback.
+
+    @return On success, zero is returned.  On error, -1 is returned and
+            #red_errno is set appropriately.
+
+    <b>Errno values</b>
+    - #RED_EINVAL: Volume is not mounted; or @p pszVolume is `NULL`.
+    - #RED_EBUSY:  A discarded block is still referenced.
+    - #RED_ENOENT: @p pszVolume is not a valid volume path prefix.
+    - #RED_EUSERS: Cannot become a file system user: too many users.
+    - #RED_EBUSY:  There are still open handles for this file system volume.
+    - #RED_EROFS:  The file system volume is read-only.
+*/
+int32_t red_rollback(
+    const char *pszVolume)
+{
+    REDSTATUS   ret;
+
+    ret = PosixEnter();
+    if(ret == 0)
+    {
+        uint8_t bVolNum;
+
+        ret = RedPathVolumeLookup(pszVolume, &bVolNum);
+
+        if(ret == 0)
+        {
+            uint16_t    uHandleIdx;
+
+            /*  Do not rollback the volume if it still has open handles.
+            */
+            for(uHandleIdx = 0U; uHandleIdx < REDCONF_HANDLE_COUNT; uHandleIdx++)
+            {
+                const REDHANDLE *pHandle = &gaHandle[uHandleIdx];
+
+                if((pHandle->ulInode != INODE_INVALID) && (pHandle->bVolNum == bVolNum))
+                {
+                    ret = -RED_EBUSY;
+                    break;
+                }
+            }
+        }
+
+        if(ret == 0)
+        {
+            ret = RedCoreVolRollback();
         }
 
         PosixLeave();


### PR DESCRIPTION
This check-in adds a red_rollback() feature to Reliance-Edge

It is adding:
- A red_rollback() call at posix level
- A RedCoreVolRollback() call in the core API

Signed-off-by: Jean-Christophe Dubois <jcd@tribudubois.net>