### PR TITLE
Initialized ret to 0 in DiskGetGeometry

### DIFF
--- a/os/freertos/services/osbdev_fatfs.h
+++ b/os/freertos/services/osbdev_fatfs.h
@@ -122,7 +122,7 @@ static REDSTATUS DiskGetGeometry(
     uint8_t     bVolNum,
     BDEVINFO   *pInfo)
 {
-    REDSTATUS   ret;
+    REDSTATUS   ret = 0;
     WORD        wSectorSize;
     DWORD       dwSectorCount;
     DRESULT     result;


### PR DESCRIPTION
An uninitialized ret value would result in DiskGetGeometry always returning RED_EIO after optimization.